### PR TITLE
学部と学科が非対応なユーザも学生として判定されてしまう

### DIFF
--- a/spec/log_parser/record/content/user_spec.rb
+++ b/spec/log_parser/record/content/user_spec.rb
@@ -34,6 +34,11 @@ describe LogParser::Record::Content::User do
      :expect  => {:student?   => false,
                   :join_year  => nil,
                   :faculty    => nil,
+                  :department => nil}},
+    {:user_id => 'ak1161054',
+     :expect  => {:student?   => false,
+                  :join_year  => nil,
+                  :faculty    => nil,
                   :department => nil}}
   ]
 


### PR DESCRIPTION
## YAML

関係あるとこだけ

``` yaml
:faculty:
  keizai:
    - ak
  hoken:
    - ah

:department:
  keiei_keizai:
    - 11
    - 12
  hoken_fukushi:
    - 61
    - 62

:student_id:
  :legal_pattern:
    !ruby/regexp /\A(?<faculty>\w{2})(?<join_year>\d{1,2})(?<department>\d{2})(?<range_number>\d{3})\z/
```
## Results

```
Failures:

  1) LogParser::Record::Content::User when user_id is 'ak1161054' behaves like return values #student? should eq false
     Failure/Error: it { expect(user.student?).to eq item[:expect][:student?] }

       expected: false
            got: true

       (compared using ==)
     Shared Example Group: "return values" called from ./spec/log_parser/record/content/user_spec.rb:67
     # ./spec/log_parser/record/content/user_spec.rb:49:in `block (4 levels) in <top (required)>'

  2) LogParser::Record::Content::User when user_id is 'ak1161054' behaves like return values #join_year should eq nil
     Failure/Error: it { expect(user.join_year).to eq item[:expect][:join_year] }

       expected: nil
            got: "11"

       (compared using ==)
     Shared Example Group: "return values" called from ./spec/log_parser/record/content/user_spec.rb:67
     # ./spec/log_parser/record/content/user_spec.rb:53:in `block (4 levels) in <top (required)>'

  3) LogParser::Record::Content::User when user_id is 'ak1161054' behaves like return values #faculty should eq nil
     Failure/Error: it { expect(user.faculty).to eq item[:expect][:faculty] }

       expected: nil
            got: "keizai"

       (compared using ==)
     Shared Example Group: "return values" called from ./spec/log_parser/record/content/user_spec.rb:67
     # ./spec/log_parser/record/content/user_spec.rb:57:in `block (4 levels) in <top (required)>'

  4) LogParser::Record::Content::User when user_id is 'ak1161054' behaves like return values #faculty should eq nil
     Failure/Error: it { expect(user.department).to eq item[:expect][:department] }

       expected: nil
            got: "hoken_fukushi"

       (compared using ==)
     Shared Example Group: "return values" called from ./spec/log_parser/record/content/user_spec.rb:67
     # ./spec/log_parser/record/content/user_spec.rb:61:in `block (4 levels) in <top (required)>'
```

経済学部の保健福祉学科の学生として判定されてしまう
## Expect
- `User#student?`が`false`を返すこと
- `User#join_year`, `User#faculty`, `User#department`が`nil`を返すこと
